### PR TITLE
Update Canvas++ for Google Manifest V3

### DIFF
--- a/layout_mod.js
+++ b/layout_mod.js
@@ -16,7 +16,7 @@ function init_layout() {
         
     var right_bar = document.getElementById("right-side-wrapper");
     right_bar.parentNode.removeChild(right_bar);
-    var dash = document.getElementById("dashboard");
+    var dash = document.getElementById("main");
     
 
 
@@ -24,11 +24,13 @@ function init_layout() {
     var header = document.getElementById("header");
 
     header.parentNode.removeChild(header);
-    main_panel.prepend(header);
+    //main_panel.prepend(header);
+    
+    var mobile_header = document.getElementById("mobile-header");
+    mobile_header.parentNode.removeChild(mobile_header);
 
 
     var collapse = document.createElement("button");
-    collapse.innerHTML = ">>";
     collapse.id = "sidebar";
     collapse.addEventListener("click", function () {
         if (right_bar.style.position == "sticky" || right_bar.style.right == "") {
@@ -42,9 +44,15 @@ function init_layout() {
         }
     })
 
+    // collapse sidebar by default
+    right_bar.style.right = -100 + "vw";
+    right_bar.style.position = "absolute";
+    collapse.innerHTML = " <<";
+
+
     dash.append(class_wind);
     dash.append(right_bar)
-    dash.prepend(collapse);
+    //dash.prepend(collapse);
 
     trial();
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Canvas++",
     "version": "0.1",
     "permissions": ["activeTab"],

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "version": "0.1",
     "permissions": ["activeTab"],
     "content_scripts": [{
-        "matches": ["https://canvas.liberty.edu/*"],
+        "matches": ["https://canvas.liberty.edu/"],
         "js": ["layout_mod.js"],
         "css": ["cv_styles.css"]
     }]


### PR DESCRIPTION
# This project deserves a longer lifespan.

> Given that the Canvas website is subject to frequent change, this update may not last for very long. However, I love the idea of this extension and I have been using it ever since I found it. Just in case you would like to see how I patched it up for my own use, here are some updates:

- <code>manifest.json</code> has been updated (very slightly) for Chrome's new Manifest V3.
- <code>manifest.json</code> has been altered such that the extension only applies to the exact url <code>canvas.liberty.edu</code> with no trailing characters.
  > This is so that the extension will disable when entering a quiz rather than breaking the quiz page. Also, simply adding a <code>/</code> to the end of the url will disable the extension when the user needs to access some functionality blocked by the extension.
- <code>layout_mod.js</code> has been updated to account for changes to the Canvas website.
  > I had to do some guesswork with this trying to figure out what the original extension intended to do, so this version may look different than the original. Also, I chose to hide the ToDo list because its presence broke the layout and its buttons broke the page.